### PR TITLE
ci: add codeql analysis to github actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,9 +5,6 @@ name: "CodeQL Vulnerability Detection"
 on:
   push:
     branches: [ main ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ main ]
   schedule:
     - cron: '39 13 * * 2'
 
@@ -33,6 +30,6 @@ jobs:
       uses: github/codeql-action/init@v1
       with:
         languages: ${{ matrix.language }}
-      
+
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,38 @@
+
+# https://codeql.github.com/docs/
+name: "CodeQL Vulnerability Detection"
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ main ]
+  schedule:
+    - cron: '39 13 * * 2'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'python' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+      
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -22,7 +22,7 @@ For dev and production.
 curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
 ```
 + Run `poetry install` (for development) or `poetry install --no-dev` (for production) in the directory of the project.
-+ Switch your python version to the created virtualenv.
++ Use `poetry shell` to enter the virtual environment, or adjust your editor/IDE accordingly.
 + (For development) Run `pre-commit install`.
 
 ## Nginx


### PR DESCRIPTION
Este es un pequeño complemento al linter que ya tenemos que además detecta vulnerabilidades comunes utilizando [CodeQL](https://codeql.github.com/docs/), los que se muestra en la pestaña de Seguridad del repositorio.

Lo configuré para que solo escanee commits a `main` y una vez cada martes, no en PRs porque se demora mucho y la idea no es que bloquee.