### PR TITLE
fix(dev): add node and psql to devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,6 +9,18 @@ ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 RUN if [ "$USER_GID" != "1000" ] || [ "$USER_UID" != "1000" ]; then groupmod --gid $USER_GID vscode && usermod --uid $USER_UID --gid $USER_GID vscode; fi
 
+# Add PSQL repo
+RUN sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+RUN apt-get update
+
+# Install the PSQL client
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends postgresql-client
+
+ARG NODE_VERSION="lts/*"
+ARG INSTALL_NODE="true"
+RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+
 # Install poetry
 USER vscode
 RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python3 -

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,7 @@
 			"username": "django",
 			"password": "django"
 		}],
-		"python.pythonPath": "/workspace/.venv/python",
+		"python.pythonPath": "/workspace/.venv/bin/python",
 		"python.venvPath": "/workspace/.venv/",
 		"python.languageServer": "Pylance",
 		"python.linting.enabled": true,

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,9 +14,9 @@
 			"previewLimit": 50,
 			"server": "localhost",
 			"port": 5432,
-			"database": "postgres",
-			"username": "postgres",
-			"password": "postgres"
+			"database": "django",
+			"username": "django",
+			"password": "django"
 		}],
 		"python.pythonPath": "/workspace/.venv/python",
 		"python.venvPath": "/workspace/.venv/",
@@ -48,7 +48,7 @@
 	"forwardPorts": [5000, 5432],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "$HOME/.local/bin/poetry install && cp -n /workspace/.env.example /workspace/.env && /workspace/.venv/bin/pre-commit install && /workspace/.venv/bin/python /workspace/manage.py migrate",
+	"postCreateCommand": "$HOME/.local/bin/poetry install && cp -n /workspace/.env.example /workspace/.env && /workspace/.venv/bin/pre-commit install && cd front/assets/ && npm install && cd /workspace && /workspace/.venv/bin/python /workspace/manage.py migrate ",
 
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode",
@@ -57,8 +57,8 @@
 		"PATH": "${containerEnv:PATH}:${containerEnv:HOME}/.local/bin/",
 		"DEBUG": "True",
 		"LANGUAGE": "es-cl",
-		"PSQL_DB": "postgres",
-		"PSQL_USER": "postgres",
-		"PSQL_PASSWD": "postgres"
+		"PSQL_DB": "django",
+		"PSQL_USER": "django",
+		"PSQL_PASSWD": "django"
 	},
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -8,6 +8,10 @@ services:
       args:
         # [Choice] Python version: 3, 3.8, 3.7, 3.6
         VARIANT: 3.9
+        # [Choice] Node.js version
+        INSTALL_NODE: "true"
+        NODE_VERSION: "lts/*"
+
         # On Linux, you may need to update USER_UID and USER_GID below if not your local UID is not 1000.
         USER_UID: 1000
         USER_GID: 1000
@@ -27,9 +31,9 @@ services:
     volumes:
       - postgres-data:/var/lib/postgresql/data
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_DB: postgres
-      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: django
+      POSTGRES_DB: django
+      POSTGRES_PASSWORD: django
 
 volumes:
   postgres-data:

--- a/.env.example
+++ b/.env.example
@@ -7,9 +7,9 @@ TIME_ZONE="America/Santiago"
 SECRET_KEY=
 
 # Postgres
-PSQL_DB=postgres
-PSQL_USER=postgres
-PSQL_PASSWD=postgres
+PSQL_DB=django
+PSQL_USER=django
+PSQL_PASSWD=django
 
 # OAuth - Needed for local testing
 GOOGLE_AUTH_CLIENT=

--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,7 @@ bin
 lib
 lib64
 pyvenv.cfg
+
+# SQL Dumps
+*.sql
+*.dump

--- a/docs/BACKUPS.md
+++ b/docs/BACKUPS.md
@@ -7,5 +7,5 @@ SCP from local:
 Load backup to DB:
 ```
 scp YY-MM-DD.dump user@host:/srv/ramosuc/database/
-pg_restore -U django -d ramosuc -c -v YY-MM-DD.dump
+pg_restore -U django -d ramosuc -c -v --if-exists YY-MM-DD.dump
 ```

--- a/ramosuc/settings.py
+++ b/ramosuc/settings.py
@@ -83,8 +83,8 @@ DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql_psycopg2",
         "NAME": os.getenv("PSQL_DB", "django"),
-        "USER": os.getenv("PSQL_USER", "postgres"),
-        "PASSWORD": os.getenv("PSQL_PASSWD", "postgres"),
+        "USER": os.getenv("PSQL_USER", "django"),
+        "PASSWORD": os.getenv("PSQL_PASSWD", "django"),
         "HOST": os.getenv("PSQL_HOST", "localhost"),
         "PORT": os.getenv("PSQL_PORT", ""),
     }


### PR DESCRIPTION
Para facilitar trabajar con los backups en el devcontainer agregué el cliente de PostgreSQL en la máquina, y cambié las credenciales internas a `django` reflejando la BBDD real.

También agregué node al contenedor y agregué el `npm install` al startup. Arregla el bug mencionado en #12 