### PR TITLE
feat: add meta tags

### DIFF
--- a/apps/courses/context_processors.py
+++ b/apps/courses/context_processors.py
@@ -1,0 +1,12 @@
+DESCRIPTION = (
+    "Buscador de ramos para la Universidad Católica, "
+    "ideal para planificar tu horario y encontrar electivos. "
+    "Una alternativa a Buscacursos UC."
+)
+
+IMG_PATH = "/dist/favicon.ico"
+
+
+def defaults(_request):
+    "Loads the default template variables"
+    return {"fallback_description": DESCRIPTION, "fallback_img_path": IMG_PATH}

--- a/front/templates/base.html
+++ b/front/templates/base.html
@@ -5,7 +5,16 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{% block title %}{% endblock %} - RamosUC</title>
+
+    <title>{% if page_title %}{{ page_title }} - {% endif %}RamosUC</title>
+    <meta property="og:title" content="{% if page_title %}{{ page_title }} - {% endif %}RamosUC" />
+    <meta property="og:description" content="{% firstof page_description fallback_description %}"/>
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="{{ request.path }}" />
+    <meta property="og:image" content="{% firstof page_img_path fallback_img_path %}" />
+    <meta name="author" content="Nicolas Mc Intyre">
+    <meta name="keywords" content="UC, Buscacursos, Ramos, Universidad Catolica, horario, ramos uc, buscador, cursos, banner uc">
+    <meta name="description" content="{% firstof page_description fallback_description %}">
 
     {% if GA_CODE %}
     <script async src="https://www.googletagmanager.com/gtag/js?id={{ GA_CODE }}"></script>

--- a/ramosuc/settings.py
+++ b/ramosuc/settings.py
@@ -70,6 +70,7 @@ TEMPLATES = [
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
                 "apps.google_analytics.context_processors.ga_code",
+                "apps.courses.context_processors.defaults",
             ],
         },
     },


### PR DESCRIPTION
Añade un template base de meta tags. Cada función de cada vista tiene que entregarle al template que título, descripción o imagen quiere mostrar, no el template respectivo con _block_ (como estaba antes).

resolves #41 