### PR TITLE
fix: cookie regex

### DIFF
--- a/front/assets/src/utils/cookies.js
+++ b/front/assets/src/utils/cookies.js
@@ -8,7 +8,7 @@ const setCookie = (cname, cvalue, exdays) => {
 
 // Get the value of a cookie by name, or empty string if not exists
 const getCookie = cname => {
-    const cookie_regrex = `${cname}=(?<value>[^;]*?);`
+    const cookie_regrex = `${cname}=(?<value>[^;]*?)(;|$)`
     const match = document.cookie.match(cookie_regrex)
     return match ? match.groups.value : ""
 }


### PR DESCRIPTION
Arregla la expresión regular para obtener las cookies.

Es prácticamente el [mismo commit](https://github.com/open-source-uc/ramos-uc/pull/45/commits/456d21efabfb893807dfb6ef141afd780917fc9a) realizado en la rama `aurmeneta:main` de la PR #45. Se hace aparte para tener el arreglo antes de llevar el avance a producción.

fixes #48