### PR TITLE
fix: cache posible values

### DIFF
--- a/apps/courses/views.py
+++ b/apps/courses/views.py
@@ -14,7 +14,7 @@ def home(request):
     return render(request, "index.html")
 
 
-def generate_possible_values():
+def get_fields_values():
     return {
         "mods": ["8:30", "10:00", "11:30", "2:00", "3:30", "5:00", "6:30", "8:00"],
         "schools": Course.objects.available("school"),
@@ -28,7 +28,7 @@ def generate_possible_values():
 # Planner index
 @cache_control(private=True, max_age=3600 * 12)
 def planner(request):
-    data = cache.get_or_set("possible_values", generate_possible_values, 3600 * 12)
+    data = cache.get_or_set("possible_values", get_fields_values, 3600 * 12)
     return render(request, "courses/planner.html", data)
 
 
@@ -301,7 +301,7 @@ def browse(request):
             },
         )
 
-    data = cache.get_or_set("possible_values", generate_possible_values, 3600 * 12)
+    data = cache.get_or_set("possible_values", get_fields_values, 3600 * 12)
     return render(request, "courses/browse.html", data)
 
 
@@ -324,5 +324,5 @@ def search(request):
 # Crea
 @cache_control(must_revalidate=True)
 def create(request):
-    data = cache.get_or_set("possible_values", generate_possible_values, 3600 * 12)
+    data = cache.get_or_set("possible_values", get_fields_values, 3600 * 12)
     return render(request, "courses/create.html", data)

--- a/apps/courses/views.py
+++ b/apps/courses/views.py
@@ -14,21 +14,21 @@ def home(request):
     return render(request, "index.html")
 
 
+def generate_possible_values():
+    return {
+        "mods": ["8:30", "10:00", "11:30", "2:00", "3:30", "5:00", "6:30", "8:00"],
+        "schools": Course.objects.available("school"),
+        "campuses": Section.objects.available("campus"),
+        "formats": Section.objects.available("format"),
+        "categories": Course.objects.available("category"),
+        "areas": Course.objects.available("area"),
+    }
+
+
 # Planner index
 @cache_control(private=True, max_age=3600 * 12)
 def planner(request):
-    data = cache.get_or_set(
-        "planner_data",
-        {
-            "mods": ["8:30", "10:00", "11:30", "2:00", "3:30", "5:00", "6:30", "8:00"],
-            "schools": Course.objects.available("school"),
-            "campuses": Section.objects.available("campus"),
-            "formats": Section.objects.available("format"),
-            "categories": Course.objects.available("category"),
-            "areas": Course.objects.available("area"),
-        },
-        3600 * 12,
-    )
+    data = cache.get_or_set("possible_values", generate_possible_values, 3600 * 12)
     return render(request, "courses/planner.html", data)
 
 
@@ -301,11 +301,8 @@ def browse(request):
             },
         )
 
-    # Case all schools
-    cached_schools = cache.get_or_set(
-        "all_schools", {"schools": Course.objects.available("school")}, 3600 * 24
-    )
-    return render(request, "courses/browse.html", cached_schools)
+    data = cache.get_or_set("possible_values", generate_possible_values, 3600 * 12)
+    return render(request, "courses/browse.html", data)
 
 
 # Search
@@ -327,16 +324,5 @@ def search(request):
 # Crea
 @cache_control(must_revalidate=True)
 def create(request):
-    data = cache.get_or_set(
-        "create_data",
-        {
-            "mods": ["8:30", "10:00", "11:30", "2:00", "3:30", "5:00", "6:30", "8:00"],
-            "schools": Course.objects.available("school"),
-            "campuses": Section.objects.available("campus"),
-            "formats": Section.objects.available("format"),
-            "categories": Course.objects.available("category"),
-            "areas": Course.objects.available("area"),
-        },
-        3600 * 12,
-    )
+    data = cache.get_or_set("possible_values", generate_possible_values, 3600 * 12)
     return render(request, "courses/create.html", data)


### PR DESCRIPTION
Esta PR realiza un cambio en el funcionamiento del caché, que se resume en lo siguiente:

```python
cache.get_or_set("result", expensive_computation())  # ❌
cache.get_or_set("result", expensive_computation)    # ✔
```

`cache.get_or_set` se utiliza 3 veces en la aplicación y en todas se estaba entregando un diccionario para hacer el `set`.

El problema es que, al momento de llamar a `get_or_set` este diccionario ya está generado, y por lo tanto, **también debería haberse realizado las 5 y 1 consultas respectivas de cada uno de estos casos**, entonces no se está evitando repetir la operación de generar estos datos.

Para evitar esto se entrega una función que será llamada solo si no existe el elemento en caché ([documentación](https://docs.djangoproject.com/en/3.2/topics/cache/#django.core.caches.cache.get_or_set)).

---

Para probar la diferencia, corrí el servidor en modo de producción, cambie el tiempo de caché del cliente en `cache_control` a 0, el tiempo de caché de los datos del en `get_or_set` a 180 y borré tanto el caché del navegador como el del servidor.

El promedio de respuesta de planifica, medido por el navegador, **bajó de 116ms a 30ms** (n=10). Esto debe afectar también al creador de horarios en la misma proporción, y en una proporción menor al navegador de cursos.

---

Además junté los cachés en 1, ya que 2 poseían la misma información y el último tenía un subconjunto de datos del los otros 2.
